### PR TITLE
Fix issue #2 open_basedir warnings

### DIFF
--- a/src/Converter.php
+++ b/src/Converter.php
@@ -44,8 +44,8 @@ class Converter implements ConverterInterface
 
             // or traveling the tree via `..`
             // attempt to resolve path, or assume it's fine if it doesn't exist
-            $from = realpath($from) ?: $from;
-            $to = realpath($to) ?: $to;
+            $from = @realpath($from) ?: $from;
+            $to = @realpath($to) ?: $to;
         }
 
         $from = $this->dirname($from);
@@ -169,11 +169,11 @@ class Converter implements ConverterInterface
      */
     protected function dirname($path)
     {
-        if (is_file($path)) {
+        if (@is_file($path)) {
             return dirname($path);
         }
 
-        if (is_dir($path)) {
+        if (@is_dir($path)) {
             return rtrim($path, '/');
         }
 


### PR DESCRIPTION
Add errors suppression on `realpath()`, `is_file()` and `is_dir()` to prevent PHP warning on some configurations with open_basedir restrictions